### PR TITLE
yellowの前後反転をhostname判定で個体別に補正

### DIFF
--- a/include/M2006Ros2.hpp
+++ b/include/M2006Ros2.hpp
@@ -55,6 +55,10 @@ private:
   std::vector<std::string> joint_names_;
   std::string joint_name_;
   rclcpp::Time last_keep_alive_time_;
+  // yellow機体は左右の配線都合でsendVelocityCanへの割り当てを反転させないと前後が逆になる
+  // (pink等は現状のままで正しく動くため、pinkに影響しないようhostnameで機体を判定する。
+  //  2026-07-27判明: 前後逆・左右回転は正常、という症状から導出した補正)
+  bool invert_wheel_direction_ = false;
 
   enum Params
   {

--- a/src/M2006Ros2.cpp
+++ b/src/M2006Ros2.cpp
@@ -1,5 +1,7 @@
 #include "M2006Ros2.hpp"
 
+#include <unistd.h>
+
 namespace dji_ros_controller
 {
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -23,6 +25,17 @@ CallbackReturn M2006Ros2::on_init(const hardware_interface::HardwareInfo& info)
   hw_velocities_.resize(info.joints.size(), 0.0);
   hw_efforts_.resize(info.joints.size(), 0.0);
   joint_name_ = info_.hardware_parameters["joint_name"];
+
+  // yellowだけ左右の配線都合でwrite()の出力を反転させる(pinkは現状のままで正しい)
+  {
+    char hostname_buf[256] = { 0 };
+    if (gethostname(hostname_buf, sizeof(hostname_buf) - 1) == 0)
+    {
+      invert_wheel_direction_ = std::string(hostname_buf).find("yellow") != std::string::npos;
+    }
+    RCLCPP_INFO(rclcpp::get_logger("M2006Ros2"), "hostname=%s invert_wheel_direction_=%s", hostname_buf,
+               invert_wheel_direction_ ? "true" : "false");
+  }
 
   for (const auto& joint : info.joints)
   {
@@ -166,6 +179,12 @@ hardware_interface::return_type M2006Ros2::write(const rclcpp::Time& time, const
     dji_can_->sendVelocityCan(keepalive_velocity, -keepalive_velocity);
 
     last_keep_alive_time_ = now;
+  }
+  else if (invert_wheel_direction_)
+  {
+    // 前後反転の補正(回転方向は元のまま維持されるよう導出した式。導出根拠は
+    // invert_wheel_direction_ 宣言部のコメント参照)
+    dji_can_->sendVelocityCan(-1.0 * hw_commands_[1], hw_commands_[0]);
   }
   else
   {


### PR DESCRIPTION
## Summary
- yellowで「前後は逆だが左右回転は正常」という症状が発生。`<ros2_control>`ブロックで`right_wheel_joint`がjoint[0]、`left_wheel_joint`がjoint[1]の順で定義されているため、`M2006Ros2::write()`の`sendVelocityCan(hw_commands_[0], -1.0 * hw_commands_[1])`がpinkでは正しく動く一方、yellowの物理配線差で前後反転を起こしていた
- 2ケース(前後・回転)の観測結果から回転方向を保ったまま前後だけ反転させる式 `sendVelocityCan(-1.0 * hw_commands_[1], hw_commands_[0])` を連立方程式で導出
- pinkに影響しないよう、hostnameに`yellow`を含む機体でのみ新しい式を使う(`invert_wheel_direction_`フラグ、デフォルトfalseで従来通り)

## Test plan
- [x] yellow実機でweb操作による前後移動・左右回転が正しい方向に動くことを確認済み
- [ ] pink実機で本PRの影響がない(従来通り動く)ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SSyCz2pt9eU8hiXY2EPdv